### PR TITLE
Fix: update ETL service base to facilitate batch processing

### DIFF
--- a/api_etl/adapters/base.py
+++ b/api_etl/adapters/base.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any
+from typing import Any, Iterable
 
 
 class DataAdapter(metaclass=abc.ABCMeta):
@@ -12,7 +12,7 @@ class DataAdapter(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def transform(self, data: Any) -> Any:
+    def transform(self, data: Iterable[Any]) -> Iterable[Any]:
         """
         Transform method of data adapter should be designed with specific data source and sink.
         The contract is dependent only on those components.

--- a/api_etl/adapters/exampleIndividialAdapter.py
+++ b/api_etl/adapters/exampleIndividialAdapter.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Iterable
 
 from api_etl.adapters.base import DataAdapter
 from api_etl.apps import ApiEtlConfig
@@ -9,12 +9,15 @@ class ExampleIndividualAdapter(DataAdapter):
     Adapter allowing data transformation form ExampleIndividualSource to IndividualService input
     """
 
-    def transform(self, data: Any) -> Any:
+    def transform(self, data: Iterable[Any]) -> Iterable[Any]:
         """
         Transform paginated result of the ExampleIndividualSource
         Input data is assumed to be Iterable of pages from the example API
         """
         result = []
+
+        if data is None:
+            raise self.Error(f"Invalid input, expect input not to be None")
 
         for row in data:
             row.pop("id", None)

--- a/api_etl/adapters/exampleIndividialAdapter.py
+++ b/api_etl/adapters/exampleIndividialAdapter.py
@@ -16,16 +16,12 @@ class ExampleIndividualAdapter(DataAdapter):
         """
         result = []
 
-        for page in data:
-            if not "rows" in page:
-                raise self.Error("Invalid input, rows field required")
-
-            for row in page["rows"]:
-                row.pop("id", None)
-                result_row = {"first_name": row.pop(ApiEtlConfig.adapter_first_name_field) or "empty",
-                              "last_name": row.pop(ApiEtlConfig.adapter_last_name_field) or "empty",
-                              "dob": row.pop(ApiEtlConfig.adapter_dob_field) or "1970-01-01",
-                              "json_ext": row}
-                result.append(result_row)
+        for row in data:
+            row.pop("id", None)
+            result_row = {"first_name": row.pop(ApiEtlConfig.adapter_first_name_field) or "empty",
+                          "last_name": row.pop(ApiEtlConfig.adapter_last_name_field) or "empty",
+                          "dob": row.pop(ApiEtlConfig.adapter_dob_field) or "1970-01-01",
+                          "json_ext": row}
+            result.append(result_row)
 
         return result

--- a/api_etl/apps.py
+++ b/api_etl/apps.py
@@ -17,7 +17,6 @@ DEFAULT_CONFIG = {
     "adapter_last_name_field": "lastName",
     "adapter_dob_field": "dateOfBirth",
 
-    "skip_integration_test": True,
     "gql_query_api_etl_rule_perms": ["953001"],
     "gql_mutation_execute_api_etl_rule_perms": ["953002"],
 }
@@ -41,7 +40,6 @@ class ApiEtlConfig(AppConfig):
     adapter_last_name_field = None
     adapter_dob_field = None
 
-    skip_integration_test = None
     gql_query_api_etl_rule_perms = None
     gql_mutation_execute_api_etl_rule_perms = None
 

--- a/api_etl/services/base.py
+++ b/api_etl/services/base.py
@@ -22,25 +22,12 @@ class ETLService(metaclass=abc.ABCMeta):
         self.sink = sink
 
     def execute(self):
-        """
-        Execute the ETL pipeline created by chaining the source, adapter and sink
-        """
         try:
-            raw_data = self.source.pull()
-        except self.source.Error as e:
-            logger.error("Error while pulling data from source: %s", str(e), exc_info=e)
-            return self._error_result(str(e))
-
-        try:
-            transformed_data = self.adapter.transform(raw_data)
-        except self.adapter.Error as e:
-            logger.error("Error while transforming data: %s", str(e), exc_info=e)
-            return self._error_result(str(e))
-
-        try:
-            self.sink.push(transformed_data)
-        except self.sink.Error as e:
-            logger.error("Error while pushing data to sink: %s", str(e), exc_info=e)
+            for raw_batch in self.source.pull():
+                transformed_batch = self.adapter.transform(raw_batch)
+                self.sink.push(transformed_batch)
+        except Exception as e:
+            logger.error("Error in ETL pipeline: %s", str(e), exc_info=e)
             return self._error_result(str(e))
 
         return self._success_result()

--- a/api_etl/sources/base.py
+++ b/api_etl/sources/base.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any
+from typing import Any, Generator
 
 
 class DataSource(metaclass=abc.ABCMeta):
@@ -12,5 +12,5 @@ class DataSource(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def pull(self) -> Any:
+    def pull(self) -> Generator[Any, None, None]:
         raise NotImplementedError("pull() not implemented")

--- a/api_etl/sources/exampleIndividualSource.py
+++ b/api_etl/sources/exampleIndividualSource.py
@@ -37,8 +37,10 @@ class ExampleIndividualSource(DataSource):
         session = requests.Session()
         while in_progress:
             logger.debug("Fetching index: %s, batch size: %s", current_index, ApiEtlConfig.source_batch_size)
-            res = session.request(method, url, headers=headers,
-                                  params={"current": current_index, "rowCount": ApiEtlConfig.source_batch_size})
+            res = session.request(
+                method, url, headers=headers,
+                params={"current": current_index, "rowCount": ApiEtlConfig.source_batch_size}
+            )
 
             if not res.ok:
                 logger.error("HTTP Request failed: %s %s", res.status_code, res.reason)
@@ -50,10 +52,12 @@ class ExampleIndividualSource(DataSource):
                 logger.error("HTTP Error response: %s %s", body.get("message"), body.get("result"))
                 raise self.Error(f"HTTP Error response: {body.get('message')} {body.get('result')}")
 
-            if body["rowCount"] < ApiEtlConfig.source_batch_size or len(body["rows"]) < ApiEtlConfig.source_batch_size:
+            rows = body.get("rows", [])
+            if rows:
+                yield rows
+
+            # Determine if we've reached the last page
+            if len(rows) < ApiEtlConfig.source_batch_size:
                 in_progress = False
-
-            pages.append(body)
-            current_index += ApiEtlConfig.source_batch_size
-
-        return pages
+            else:
+                current_index += ApiEtlConfig.source_batch_size

--- a/api_etl/tests/test_exampleIndividialAdapter.py
+++ b/api_etl/tests/test_exampleIndividialAdapter.py
@@ -15,15 +15,10 @@ class ExampleIndividualAdapterTestCase(TestCase):
 
     def test_transform_success(self):
         data = [{
-            'current': 0,
-            'rowCount': 1,
-            'rows': [{
-                "firstName": self._FN_1,
-                "lastName": self._LN_1,
-                "dateOfBirth": self._DOB_1,
-                **self._EXT_1,
-            }],
-            'total': 100
+            "firstName": self._FN_1,
+            "lastName": self._LN_1,
+            "dateOfBirth": self._DOB_1,
+            **self._EXT_1,
         }]
 
         expected = [{
@@ -37,23 +32,13 @@ class ExampleIndividualAdapterTestCase(TestCase):
         self.assertEquals(actual, expected)
 
     def test_no_rows(self):
-        data = [{
-            'current': 0,
-            'rowCount': 0,
-            'rows': [],
-            'total': 0
-        }]
-
+        data = []
         expected = []
 
         actual = self.adapter.transform(data)
         self.assertEquals(actual, expected)
 
     def test_no_rows_item(self):
-        data = [{
-            'current': 0,
-            'rowCount': 0,
-            'total': 0
-        }]
+        data = None
 
         self.assertRaises(self.adapter.Error, self.adapter.transform, data)

--- a/api_etl/tests/test_exampleIndividualETLService.py
+++ b/api_etl/tests/test_exampleIndividualETLService.py
@@ -1,23 +1,61 @@
 import logging
-from unittest import skipIf
+from unittest.mock import patch, MagicMock
 
 from django.test import TestCase
 
 from api_etl.apps import ApiEtlConfig
-from api_etl.services.exampleIndividualETLService import ExampleIndividualETLService
+from api_etl.auth_provider import get_auth_provider
+from api_etl.services import ExampleIndividualETLService
+from api_etl.sources import ExampleIndividualSource
 from core.test_helpers import create_test_interactive_user
 from individual.models import Individual
 
 logger = logging.getLogger(__name__)
 
 
-class ETLServiceTestCase(TestCase):
-    @skipIf(ApiEtlConfig.skip_integration_test,
-            "This is a full integration test for the example API and should not be run with the default test suite")
-    def test_1(self):
-        user = create_test_interactive_user(username="test_admin")
+MOCKED_RESPONSE_DATA = [
+    {
+        "status": True,
+        "rowCount": 2,
+        "rows": [
+            {"firstName": "John", "lastName": "Doe", "dateOfBirth": "1990-01-01", "id": 1, "extraField": "value1"},
+            {"firstName": "Jane", "lastName": "Smith", "dateOfBirth": "1985-05-15", "id": 2, "extraField": "value2"}
+        ],
+    },
+    {
+        "status": True,
+        "rowCount": 1,
+        "rows": [
+            {"firstName": "Alice", "lastName": "Johnson", "dateOfBirth": "2000-12-12", "id": 3, "extraField": "value3"}
+        ],
+    },
+]
 
-        service = ExampleIndividualETLService(user)
+class ETLServiceTestCase(TestCase):
+
+    @patch("requests.Session.request")
+    @patch("api_etl.apps.ApiEtlConfig.source_batch_size", new=2)
+    def test_example_individual_etl_service(self, mock_request):
+        mock_request.side_effect = [
+            MagicMock(
+                ok=True,
+                json=MagicMock(return_value=page)
+            )
+            for page in MOCKED_RESPONSE_DATA
+        ]
+
+        initial_count = Individual.objects.count()
+
+        user = create_test_interactive_user(username="test_admin")
+        source = ExampleIndividualSource(get_auth_provider('noauth'))
+        service = ExampleIndividualETLService(user, source=source)
         service.execute()
 
-        logging.info("Successfully imported %s individuals", Individual.objects.count())
+        final_count = Individual.objects.count()
+
+        self.assertEqual(final_count - initial_count, 3)
+        logging.info(f"Successfully imported {final_count - initial_count} individuals")
+
+        self.assertTrue(Individual.objects.filter(first_name="John", last_name="Doe").exists())
+        self.assertTrue(Individual.objects.filter(first_name="Jane", last_name="Smith").exists())
+        self.assertTrue(Individual.objects.filter(first_name="Alice", last_name="Johnson").exists())


### PR DESCRIPTION
Existing implementation holds all data pulled from source in memory, processes all, then pushes all to sink, which won't work well with large number of records. This PR enables batch processing.